### PR TITLE
Removed the Autofac dependencies from the API plugin. Otherwise the A…

### DIFF
--- a/Nop.Plugin.Api/Nop.Plugin.Api.csproj
+++ b/Nop.Plugin.Api/Nop.Plugin.Api.csproj
@@ -33,8 +33,8 @@
     <DocumentationFile>..\..\Presentation\Nop.Web\Plugins\Nop.Plugin.Api\Nop.Plugin.Api.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.3.5.0\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac">
+      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Autofac.Integration.WebApi, Version=3.4.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">

--- a/Nop.Plugin.Api/app.config
+++ b/Nop.Plugin.Api/app.config
@@ -11,10 +11,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>

--- a/Nop.Plugin.Api/packages.config
+++ b/Nop.Plugin.Api/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.0" targetFramework="net451" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Cors" version="5.0.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
…utofac.WebApi2 package downloads the lowest version of Autofac that is 3.5.0 rather than using the 3.5.2 version that nopCommerce uses.